### PR TITLE
feat: typed errors with thiserror, encapsulate SchedulerInner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,61 @@ version = 4
 [[package]]
 name = "knitting-crab"
 version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+thiserror = "2"
 
 [dev-dependencies]

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1,3 +1,4 @@
+use crate::error::SchedulerError;
 use crate::work_item::{TaskState, WorkItem};
 use std::collections::HashMap;
 
@@ -12,12 +13,12 @@ impl DagEngine {
         }
     }
 
-    pub fn add_task(&mut self, item: WorkItem) -> Result<(), String> {
+    pub fn add_task(&mut self, item: WorkItem) -> Result<(), SchedulerError> {
         let id = item.id;
         self.tasks.insert(id, item);
         if self.has_cycle() {
             self.tasks.remove(&id);
-            return Err(format!("Adding task {} would create a cycle", id));
+            return Err(SchedulerError::CycleDetected { task_id: id });
         }
         Ok(())
     }
@@ -159,6 +160,10 @@ mod tests {
         dag.add_task(make_task(1, vec![2])).unwrap();
         let result = dag.add_task(make_task(2, vec![1]));
         assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            SchedulerError::CycleDetected { task_id: 2 }
+        ));
     }
 
     #[test]
@@ -169,7 +174,6 @@ mod tests {
 
         dag.mark_failed(1, "something went wrong".into());
         let ready = dag.ready_tasks();
-        // Task 2 depends on task 1 which failed; it should NOT be ready
         assert!(!ready.contains(&2));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SchedulerError {
+    #[error("cycle detected: adding task {task_id} would create a dependency cycle")]
+    CycleDetected { task_id: u64 },
+
+    #[error("insufficient resources: need {need_cpu} CPU, {need_ram} MB RAM, gpu={need_gpu}; available {avail_cpu} CPU, {avail_ram} MB RAM, {avail_gpu} GPU slots")]
+    InsufficientResources {
+        need_cpu: u32,
+        need_ram: u64,
+        need_gpu: bool,
+        avail_cpu: u32,
+        avail_ram: u64,
+        avail_gpu: u32,
+    },
+
+    #[error("lease conflict: task {task_id} already has an active lease")]
+    LeaseConflict { task_id: u64 },
+
+    #[error("task not found: {task_id}")]
+    TaskNotFound { task_id: u64 },
+
+    #[error("budget exhausted: {reason}")]
+    BudgetExhausted { reason: String },
+
+    #[error("invalid input: {reason}")]
+    InvalidInput { reason: String },
+}

--- a/src/lease.rs
+++ b/src/lease.rs
@@ -1,3 +1,4 @@
+use crate::error::SchedulerError;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
@@ -43,9 +44,9 @@ impl LeaseManager {
         ram: u64,
         gpu: bool,
         duration: Duration,
-    ) -> Result<Lease, String> {
+    ) -> Result<Lease, SchedulerError> {
         if self.has_active_lease(task_id) {
-            return Err(format!("Task {} already has an active lease", task_id));
+            return Err(SchedulerError::LeaseConflict { task_id });
         }
         let id = self.next_id;
         self.next_id += 1;
@@ -140,7 +141,9 @@ mod tests {
         mgr.grant_lease(42, 1, 1, 256, false, Duration::from_secs(60))
             .unwrap();
         let result = mgr.grant_lease(42, 2, 1, 256, false, Duration::from_secs(60));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("already has an active lease"));
+        assert!(matches!(
+            result.unwrap_err(),
+            SchedulerError::LeaseConflict { task_id: 42 }
+        ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod dag;
+pub mod error;
 pub mod lease;
 pub mod policy;
 pub mod resource_model;
@@ -6,6 +7,7 @@ pub mod scheduler;
 pub mod work_item;
 
 pub use dag::DagEngine;
+pub use error::SchedulerError;
 pub use lease::{Lease, LeaseManager};
 pub use policy::{BackoffStrategy, Budget};
 pub use resource_model::ResourceModel;

--- a/src/resource_model.rs
+++ b/src/resource_model.rs
@@ -1,13 +1,17 @@
+use crate::error::SchedulerError;
+
 #[derive(Debug, Clone)]
 pub struct ResourceModel {
-    pub total_cpu_cores: u32,
-    pub available_cpu_cores: u32,
-    pub total_ram_mb: u64,
-    pub available_ram_mb: u64,
-    pub total_gpu_slots: u32,
-    pub available_gpu_slots: u32,
-    pub total_network_slots: u32,
-    pub available_network_slots: u32,
+    total_cpu_cores: u32,
+    available_cpu_cores: u32,
+    total_ram_mb: u64,
+    available_ram_mb: u64,
+    total_gpu_slots: u32,
+    available_gpu_slots: u32,
+    #[allow(dead_code)]
+    total_network_slots: u32,
+    #[allow(dead_code)]
+    available_network_slots: u32,
 }
 
 impl ResourceModel {
@@ -30,13 +34,16 @@ impl ResourceModel {
             && (!gpu || self.available_gpu_slots >= 1)
     }
 
-    pub fn allocate(&mut self, cpu: u32, ram: u64, gpu: bool) -> Result<(), String> {
+    pub fn allocate(&mut self, cpu: u32, ram: u64, gpu: bool) -> Result<(), SchedulerError> {
         if !self.can_allocate(cpu, ram, gpu) {
-            return Err(format!(
-                "Insufficient resources: need {} CPU, {} MB RAM, gpu={}; available {} CPU, {} MB RAM, {} GPU slots",
-                cpu, ram, gpu,
-                self.available_cpu_cores, self.available_ram_mb, self.available_gpu_slots
-            ));
+            return Err(SchedulerError::InsufficientResources {
+                need_cpu: cpu,
+                need_ram: ram,
+                need_gpu: gpu,
+                avail_cpu: self.available_cpu_cores,
+                avail_ram: self.available_ram_mb,
+                avail_gpu: self.available_gpu_slots,
+            });
         }
         self.available_cpu_cores -= cpu;
         self.available_ram_mb -= ram;
@@ -60,6 +67,22 @@ impl ResourceModel {
         }
         let used = self.total_cpu_cores - self.available_cpu_cores;
         used as f64 / self.total_cpu_cores as f64
+    }
+
+    pub fn available_cpu(&self) -> u32 {
+        self.available_cpu_cores
+    }
+
+    pub fn total_cpu(&self) -> u32 {
+        self.total_cpu_cores
+    }
+
+    pub fn available_ram(&self) -> u64 {
+        self.available_ram_mb
+    }
+
+    pub fn available_gpu(&self) -> u32 {
+        self.available_gpu_slots
     }
 }
 
@@ -93,8 +116,18 @@ mod tests {
         let mut r = ResourceModel::new(4, 4096, 1, 4);
         r.allocate(2, 1024, true).unwrap();
         r.release(2, 1024, true);
-        assert_eq!(r.available_cpu_cores, 4);
-        assert_eq!(r.available_ram_mb, 4096);
-        assert_eq!(r.available_gpu_slots, 1);
+        assert_eq!(r.available_cpu(), 4);
+        assert_eq!(r.available_ram(), 4096);
+        assert_eq!(r.available_gpu(), 1);
+    }
+
+    #[test]
+    fn insufficient_resources_error_type() {
+        let mut r = ResourceModel::new(2, 1024, 0, 4);
+        let err = r.allocate(4, 512, false).unwrap_err();
+        assert!(matches!(
+            err,
+            SchedulerError::InsufficientResources { need_cpu: 4, .. }
+        ));
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -3,19 +3,20 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use crate::dag::DagEngine;
+use crate::error::SchedulerError;
 use crate::lease::{Lease, LeaseManager};
 use crate::resource_model::ResourceModel;
 use crate::work_item::{TaskState, WorkItem};
 
-pub struct SchedulerInner {
-    pub queue: BinaryHeap<WorkItem>,
-    pub dag: DagEngine,
-    pub resources: ResourceModel,
-    pub leases: LeaseManager,
-    pub goal_locks: HashMap<String, u64>,
-    pub cache: HashMap<String, TaskState>,
+struct SchedulerInner {
+    queue: BinaryHeap<WorkItem>,
+    dag: DagEngine,
+    resources: ResourceModel,
+    leases: LeaseManager,
+    goal_locks: HashMap<String, u64>,
+    cache: HashMap<String, TaskState>,
     /// Exit codes that are eligible for retry. If empty, all failures are retryable.
-    pub retryable_exit_codes: Vec<i32>,
+    retryable_exit_codes: Vec<i32>,
 }
 
 pub struct Scheduler {
@@ -45,7 +46,7 @@ impl Scheduler {
         self
     }
 
-    pub fn enqueue(&self, item: WorkItem) -> Result<(), String> {
+    pub fn enqueue(&self, item: WorkItem) -> Result<(), SchedulerError> {
         let mut inner = self.inner.write().unwrap();
         inner.dag.add_task(item.clone())?;
         inner.queue.push(item);
@@ -96,7 +97,7 @@ impl Scheduler {
         task: WorkItem,
         worker_id: u64,
         lease_duration: Duration,
-    ) -> Result<Lease, String> {
+    ) -> Result<Lease, SchedulerError> {
         let mut inner = self.inner.write().unwrap();
         inner.resources.allocate(
             task.required_cpu_cores,
@@ -200,14 +201,17 @@ impl Scheduler {
         inner.cache.insert(cache_key, state);
     }
 
+    pub fn resource_utilization(&self) -> f64 {
+        let inner = self.inner.read().unwrap();
+        inner.resources.utilization()
+    }
+
     fn is_retryable(retryable_codes: &[i32], exit_code: Option<i32>) -> bool {
         if retryable_codes.is_empty() {
-            // No codes configured: all failures are retryable
             return true;
         }
         match exit_code {
             Some(code) => retryable_codes.contains(&code),
-            // No exit code provided: treat as non-retryable when codes are configured
             None => false,
         }
     }
@@ -280,13 +284,7 @@ mod tests {
             .schedule_task(next, 1, Duration::from_secs(60))
             .unwrap();
         sched.complete_task(lease.id, true, None, None);
-        {
-            let inner = sched.inner.read().unwrap();
-            assert_eq!(
-                inner.resources.available_cpu_cores,
-                inner.resources.total_cpu_cores
-            );
-        }
+        assert!((sched.resource_utilization() - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -314,15 +312,16 @@ mod tests {
         let _lease = sched
             .schedule_task(next.clone(), 1, Duration::from_secs(60))
             .unwrap();
-        // Second lease for the same task should fail
         let result = sched.schedule_task(next, 2, Duration::from_secs(60));
-        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            SchedulerError::LeaseConflict { .. }
+        ));
     }
 
     #[test]
     fn permanent_fail_after_max_attempts() {
         let sched = make_scheduler();
-        // max_retries = 2, so task gets 2 retries (3 total attempts)
         let mut task = make_task(1, Priority::Batch, vec![]);
         task.max_retries = 2;
         sched.enqueue(task).unwrap();
@@ -335,7 +334,6 @@ mod tests {
                 .unwrap();
             sched.complete_task(lease.id, false, Some(1), Some("oops".into()));
         }
-        // After exhausting retries, task should not be re-queued
         assert!(
             sched.next_task().is_none(),
             "Task should be permanently failed after max retries"
@@ -351,7 +349,6 @@ mod tests {
         task.max_retries = 3;
         sched.enqueue(task).unwrap();
 
-        // Fail with non-retryable exit code 1 — should NOT retry
         let next = sched.next_task().unwrap();
         let lease = sched
             .schedule_task(next, 1, Duration::from_secs(60))
@@ -363,7 +360,6 @@ mod tests {
             "Non-retryable exit code should cause permanent failure"
         );
 
-        // Now test with a retryable exit code
         let sched2 =
             Scheduler::new(ResourceModel::new(8, 8192, 1, 4)).with_retryable_exit_codes(vec![75]);
         let mut task2 = make_task(2, Priority::Batch, vec![]);
@@ -388,17 +384,59 @@ mod tests {
         let task = make_task(1, Priority::Batch, vec![]);
         let key = task.cache_key.clone();
 
-        // Store a cached failure
         sched.store_cache(key.clone(), TaskState::Failed("previous run".into()));
-
-        // Verify the cache returns the failure
         let cached = sched.check_cache(&key);
         assert!(matches!(cached, Some(TaskState::Failed(_))));
 
-        // Policy: caller can choose to skip or re-execute based on cached state.
-        // Overwrite cache to simulate a policy that clears failed cache entries.
         sched.store_cache(key.clone(), TaskState::Pending);
         let cleared = sched.check_cache(&key);
         assert_eq!(cleared, Some(TaskState::Pending));
+    }
+
+    #[test]
+    fn resource_constrained_scheduling_skips_heavy_task() {
+        // Only 2 CPU cores available — heavy task (4 cores) should be skipped
+        // in favor of a lighter task (1 core) even though heavy has higher priority.
+        let sched = Scheduler::new(ResourceModel::new(2, 8192, 1, 4));
+
+        let mut heavy = WorkItem::new(
+            1,
+            "heavy",
+            "repo",
+            "main",
+            Priority::Interactive,
+            vec![],
+            4,
+            512,
+            false,
+            None,
+            0,
+        );
+        heavy.required_cpu_cores = 4; // needs 4 but only 2 available
+
+        let light = WorkItem::new(
+            2,
+            "light",
+            "repo",
+            "main",
+            Priority::Batch,
+            vec![],
+            1,
+            512,
+            false,
+            None,
+            0,
+        );
+
+        sched.enqueue(heavy).unwrap();
+        sched.enqueue(light).unwrap();
+
+        // next_task should skip the heavy Interactive task and pick the light Batch task
+        let next = sched.next_task().unwrap();
+        assert_eq!(
+            next.id, 2,
+            "Should schedule lighter task when heavy task exceeds resources"
+        );
+        assert_eq!(next.priority, Priority::Batch);
     }
 }


### PR DESCRIPTION
## Summary
- Add `thiserror` dependency and `SchedulerError` enum (`CycleDetected`, `InsufficientResources`, `LeaseConflict`, `TaskNotFound`, `BudgetExhausted`, `InvalidInput`)
- Replace all `Result<_, String>` with `Result<_, SchedulerError>` across dag, lease, resource_model, and scheduler modules
- Make `SchedulerInner` fields private — add accessor methods on `ResourceModel` and `Scheduler`
- Add `resource_constrained_scheduling_skips_heavy_task` test: verifies scheduler skips higher-priority task that exceeds resources in favor of a smaller lower-priority task

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all -- -D warnings` — zero warnings
- [x] `cargo test --all` — 31 tests pass (was 29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)