### PR TITLE
feat: Phase B component tests with Worker trait and FakeWorker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,14 @@ name = "knitting-crab"
 version = "0.1.0"
 dependencies = [
  "thiserror",
+ "tokio",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "proc-macro2"
@@ -52,6 +59,27 @@ name = "thiserror-impl"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 thiserror = "2"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod policy;
 pub mod resource_model;
 pub mod scheduler;
 pub mod work_item;
+pub mod worker;
 
 pub use dag::DagEngine;
 pub use error::SchedulerError;
@@ -13,3 +14,4 @@ pub use policy::{BackoffStrategy, Budget};
 pub use resource_model::ResourceModel;
 pub use scheduler::Scheduler;
 pub use work_item::{Priority, TaskState, WorkItem};
+pub use worker::{FakeWorker, TaskResult, Worker};

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,0 +1,145 @@
+use crate::work_item::WorkItem;
+use std::fmt;
+use std::time::Duration;
+
+/// Result of executing a task.
+#[derive(Debug, Clone)]
+pub struct TaskResult {
+    pub task_id: u64,
+    pub success: bool,
+    pub exit_code: Option<i32>,
+    pub reason: Option<String>,
+    pub elapsed: Duration,
+}
+
+/// A worker that can execute tasks.
+pub trait Worker: Send + Sync {
+    fn execute(&self, task: &WorkItem) -> impl std::future::Future<Output = TaskResult> + Send;
+}
+
+/// Outcome to configure on a FakeWorker.
+#[derive(Debug, Clone)]
+pub enum FakeOutcome {
+    Succeed,
+    Fail { exit_code: i32, reason: String },
+    Panic,
+}
+
+impl fmt::Display for FakeOutcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FakeOutcome::Succeed => write!(f, "Succeed"),
+            FakeOutcome::Fail { exit_code, .. } => write!(f, "Fail({})", exit_code),
+            FakeOutcome::Panic => write!(f, "Panic"),
+        }
+    }
+}
+
+/// A fake worker for component testing with configurable latency and outcomes.
+pub struct FakeWorker {
+    latency: Duration,
+    outcomes: std::sync::Mutex<Vec<FakeOutcome>>,
+}
+
+impl FakeWorker {
+    pub fn new(latency: Duration, outcomes: Vec<FakeOutcome>) -> Self {
+        FakeWorker {
+            latency,
+            outcomes: std::sync::Mutex::new(outcomes),
+        }
+    }
+
+    /// Creates a FakeWorker that always succeeds.
+    pub fn always_succeed(latency: Duration) -> Self {
+        Self {
+            latency,
+            outcomes: std::sync::Mutex::new(vec![]),
+        }
+    }
+}
+
+impl Worker for FakeWorker {
+    async fn execute(&self, task: &WorkItem) -> TaskResult {
+        tokio::time::sleep(self.latency).await;
+
+        let outcome = {
+            let mut outcomes = self.outcomes.lock().unwrap();
+            if outcomes.is_empty() {
+                FakeOutcome::Succeed
+            } else {
+                outcomes.remove(0)
+            }
+        };
+
+        match outcome {
+            FakeOutcome::Succeed => TaskResult {
+                task_id: task.id,
+                success: true,
+                exit_code: Some(0),
+                reason: None,
+                elapsed: self.latency,
+            },
+            FakeOutcome::Fail { exit_code, reason } => TaskResult {
+                task_id: task.id,
+                success: false,
+                exit_code: Some(exit_code),
+                reason: Some(reason),
+                elapsed: self.latency,
+            },
+            FakeOutcome::Panic => {
+                panic!("FakeWorker configured to panic on task {}", task.id);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::work_item::Priority;
+
+    fn make_task(id: u64) -> WorkItem {
+        WorkItem::new(
+            id,
+            format!("goal{}", id),
+            "repo",
+            "main",
+            Priority::Batch,
+            vec![],
+            1,
+            512,
+            false,
+            None,
+            3,
+        )
+    }
+
+    #[tokio::test]
+    async fn fake_worker_succeed() {
+        let worker = FakeWorker::always_succeed(Duration::from_millis(1));
+        let result = worker.execute(&make_task(1)).await;
+        assert!(result.success);
+        assert_eq!(result.exit_code, Some(0));
+    }
+
+    #[tokio::test]
+    async fn fake_worker_fail() {
+        let worker = FakeWorker::new(
+            Duration::from_millis(1),
+            vec![FakeOutcome::Fail {
+                exit_code: 1,
+                reason: "boom".into(),
+            }],
+        );
+        let result = worker.execute(&make_task(1)).await;
+        assert!(!result.success);
+        assert_eq!(result.exit_code, Some(1));
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "FakeWorker configured to panic")]
+    async fn fake_worker_panic() {
+        let worker = FakeWorker::new(Duration::from_millis(1), vec![FakeOutcome::Panic]);
+        worker.execute(&make_task(1)).await;
+    }
+}

--- a/tests/component.rs
+++ b/tests/component.rs
@@ -1,0 +1,163 @@
+use knitting_crab::{FakeWorker, Priority, ResourceModel, Scheduler, TaskResult, WorkItem, Worker};
+use std::time::Duration;
+
+fn make_task(id: u64, priority: Priority, deps: Vec<u64>) -> WorkItem {
+    WorkItem::new(
+        id,
+        format!("goal{}", id),
+        "repo",
+        "main",
+        priority,
+        deps,
+        1,
+        512,
+        false,
+        None,
+        3,
+    )
+}
+
+/// Runs tasks through the scheduler using the given worker until no more tasks are ready.
+/// Returns all TaskResults collected.
+async fn run_scheduler(sched: &Scheduler, worker: &impl Worker) -> Vec<TaskResult> {
+    let mut results = Vec::new();
+    while let Some(task) = sched.next_task() {
+        let lease = sched
+            .schedule_task(task.clone(), 1, Duration::from_secs(60))
+            .unwrap();
+        let result = worker.execute(&task).await;
+        results.push(result.clone());
+        sched.complete_task(lease.id, result.success, result.exit_code, result.reason);
+    }
+    results
+}
+
+#[tokio::test]
+async fn ten_tasks_all_succeed() {
+    let sched = Scheduler::new(ResourceModel::new(8, 8192, 1, 4));
+    let worker = FakeWorker::always_succeed(Duration::from_millis(1));
+
+    for i in 1..=10 {
+        sched
+            .enqueue(make_task(i, Priority::Batch, vec![]))
+            .unwrap();
+    }
+
+    let results = run_scheduler(&sched, &worker).await;
+    assert_eq!(results.len(), 10);
+    assert!(results.iter().all(|r| r.success));
+}
+
+#[tokio::test]
+async fn partial_failure_with_retry() {
+    use knitting_crab::worker::FakeOutcome;
+
+    let sched = Scheduler::new(ResourceModel::new(8, 8192, 1, 4));
+    // Task 1: fail once then succeed (outcomes consumed in order; empty = succeed)
+    let worker = FakeWorker::new(
+        Duration::from_millis(1),
+        vec![FakeOutcome::Fail {
+            exit_code: 1,
+            reason: "transient".into(),
+        }],
+    );
+
+    let mut task = make_task(1, Priority::Batch, vec![]);
+    task.max_retries = 2;
+    sched.enqueue(task).unwrap();
+
+    // First execution: should fail
+    let next = sched.next_task().unwrap();
+    let lease = sched
+        .schedule_task(next.clone(), 1, Duration::from_secs(60))
+        .unwrap();
+    let result = worker.execute(&next).await;
+    assert!(!result.success);
+    sched.complete_task(lease.id, result.success, result.exit_code, result.reason);
+
+    // Task should be re-queued for retry
+    let retry = sched.next_task();
+    assert!(
+        retry.is_some(),
+        "Task should be re-queued after retryable failure"
+    );
+
+    let retry_task = retry.unwrap();
+    let lease2 = sched
+        .schedule_task(retry_task.clone(), 1, Duration::from_secs(60))
+        .unwrap();
+    let result2 = worker.execute(&retry_task).await;
+    assert!(result2.success, "Second attempt should succeed");
+    sched.complete_task(
+        lease2.id,
+        result2.success,
+        result2.exit_code,
+        result2.reason,
+    );
+
+    // No more tasks
+    assert!(sched.next_task().is_none());
+}
+
+#[tokio::test]
+async fn resource_saturation() {
+    // Only 2 CPU cores — can run at most 2 tasks concurrently (each needs 1 core)
+    let sched = Scheduler::new(ResourceModel::new(2, 8192, 1, 4));
+    let worker = FakeWorker::always_succeed(Duration::from_millis(1));
+
+    for i in 1..=4 {
+        sched
+            .enqueue(make_task(i, Priority::Batch, vec![]))
+            .unwrap();
+    }
+
+    // Schedule 2 tasks — should succeed
+    let t1 = sched.next_task().unwrap();
+    let l1 = sched
+        .schedule_task(t1.clone(), 1, Duration::from_secs(60))
+        .unwrap();
+    let t2 = sched.next_task().unwrap();
+    let l2 = sched
+        .schedule_task(t2.clone(), 1, Duration::from_secs(60))
+        .unwrap();
+
+    // Third task should not be schedulable (no resources)
+    assert!(
+        sched.next_task().is_none(),
+        "No resources for a third concurrent task"
+    );
+
+    // Complete first two, freeing resources
+    let r1 = worker.execute(&t1).await;
+    sched.complete_task(l1.id, r1.success, r1.exit_code, r1.reason);
+    let r2 = worker.execute(&t2).await;
+    sched.complete_task(l2.id, r2.success, r2.exit_code, r2.reason);
+
+    // Now remaining tasks should be schedulable
+    let remaining = run_scheduler(&sched, &worker).await;
+    assert_eq!(remaining.len(), 2);
+}
+
+#[tokio::test]
+async fn dag_execution_order() {
+    // Task 2 depends on task 1; task 3 depends on task 2.
+    // Execution must respect: 1 → 2 → 3.
+    let sched = Scheduler::new(ResourceModel::new(8, 8192, 1, 4));
+    let worker = FakeWorker::always_succeed(Duration::from_millis(1));
+
+    sched
+        .enqueue(make_task(1, Priority::Batch, vec![]))
+        .unwrap();
+    sched
+        .enqueue(make_task(2, Priority::Batch, vec![1]))
+        .unwrap();
+    sched
+        .enqueue(make_task(3, Priority::Batch, vec![2]))
+        .unwrap();
+
+    let results = run_scheduler(&sched, &worker).await;
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].task_id, 1);
+    assert_eq!(results[1].task_id, 2);
+    assert_eq!(results[2].task_id, 3);
+}


### PR DESCRIPTION
## Summary
- Add `tokio` dependency for async runtime
- Define `Worker` trait with async `execute()` method and `TaskResult` return type
- Implement `FakeWorker` with configurable latency, success/failure/panic outcomes
- Add 4 component integration tests exercising the full scheduler→worker loop

New tests: `ten_tasks_all_succeed`, `partial_failure_with_retry`, `resource_saturation`, `dag_execution_order` + 3 FakeWorker unit tests

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all -- -D warnings` — zero warnings
- [x] `cargo test --all` — 46 tests pass (42 unit + 4 component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)