### PR TITLE
feat: content-addressed artifact cache with LRU eviction (Epic 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,72 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -19,18 +81,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
 name = "knitting-crab"
 version = "0.1.0"
 dependencies = [
+ "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mio"
@@ -44,10 +212,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -65,6 +249,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -86,6 +348,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -135,16 +410,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -160,3 +505,97 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+sha2 = "0.10"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "process", "io-util"] }
 
 [dev-dependencies]
+tempfile = "3"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,295 @@
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+use std::time::Instant;
+
+/// A content-addressed artifact cache with LRU eviction.
+pub struct ArtifactCache {
+    root: PathBuf,
+    max_bytes: u64,
+    /// Tracks cache entries: key → (size_bytes, last_access)
+    entries: HashMap<String, CacheEntry>,
+    total_bytes: u64,
+    hits: u64,
+    misses: u64,
+}
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    size: u64,
+    last_access: Instant,
+}
+
+impl ArtifactCache {
+    /// Creates or opens a cache at the given root directory.
+    pub fn new(root: impl Into<PathBuf>, max_bytes: u64) -> io::Result<Self> {
+        let root = root.into();
+        fs::create_dir_all(&root)?;
+
+        let mut cache = ArtifactCache {
+            root,
+            max_bytes,
+            entries: HashMap::new(),
+            total_bytes: 0,
+            hits: 0,
+            misses: 0,
+        };
+
+        // Scan existing entries
+        cache.scan_existing()?;
+        Ok(cache)
+    }
+
+    /// Computes a SHA256 content address for the given data.
+    pub fn content_key(data: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        format!("{:x}", hasher.finalize())
+    }
+
+    /// Stores data in the cache, returning the content-addressed key.
+    pub fn store(&mut self, data: &[u8]) -> io::Result<String> {
+        let key = Self::content_key(data);
+        let path = self.key_path(&key);
+
+        if path.exists() {
+            // Already cached — update access time
+            if let Some(entry) = self.entries.get_mut(&key) {
+                entry.last_access = Instant::now();
+            }
+            return Ok(key);
+        }
+
+        let size = data.len() as u64;
+
+        // Evict if necessary
+        while self.total_bytes + size > self.max_bytes && !self.entries.is_empty() {
+            self.evict_lru()?;
+        }
+
+        // If single item exceeds max, still store it (but cache will be at capacity)
+        fs::write(&path, data)?;
+        self.entries.insert(
+            key.clone(),
+            CacheEntry {
+                size,
+                last_access: Instant::now(),
+            },
+        );
+        self.total_bytes += size;
+
+        Ok(key)
+    }
+
+    /// Retrieves cached data by key. Returns None on cache miss.
+    pub fn retrieve(&mut self, key: &str) -> io::Result<Option<Vec<u8>>> {
+        let path = self.key_path(key);
+        if !path.exists() {
+            self.misses += 1;
+            return Ok(None);
+        }
+
+        self.hits += 1;
+        if let Some(entry) = self.entries.get_mut(key) {
+            entry.last_access = Instant::now();
+        }
+
+        let data = fs::read(&path)?;
+        Ok(Some(data))
+    }
+
+    /// Checks if a key exists in the cache without updating access time.
+    pub fn contains(&self, key: &str) -> bool {
+        self.entries.contains_key(key)
+    }
+
+    /// Returns (hits, misses).
+    pub fn stats(&self) -> (u64, u64) {
+        (self.hits, self.misses)
+    }
+
+    /// Returns total bytes currently cached.
+    pub fn total_cached_bytes(&self) -> u64 {
+        self.total_bytes
+    }
+
+    /// Returns number of entries in the cache.
+    pub fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn key_path(&self, key: &str) -> PathBuf {
+        self.root.join(key)
+    }
+
+    fn evict_lru(&mut self) -> io::Result<()> {
+        let oldest_key = self
+            .entries
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_access)
+            .map(|(k, _)| k.clone());
+
+        if let Some(key) = oldest_key {
+            let path = self.key_path(&key);
+            if path.exists() {
+                fs::remove_file(&path)?;
+            }
+            if let Some(entry) = self.entries.remove(&key) {
+                self.total_bytes = self.total_bytes.saturating_sub(entry.size);
+            }
+        }
+        Ok(())
+    }
+
+    fn scan_existing(&mut self) -> io::Result<()> {
+        if !self.root.exists() {
+            return Ok(());
+        }
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    let meta = entry.metadata()?;
+                    let size = meta.len();
+                    self.entries.insert(
+                        name.to_string(),
+                        CacheEntry {
+                            size,
+                            last_access: Instant::now(),
+                        },
+                    );
+                    self.total_bytes += size;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Stores a task's output artifact by cache key from a WorkItem.
+pub fn store_task_artifact(
+    cache: &mut ArtifactCache,
+    task_cache_key: &str,
+    data: &[u8],
+) -> io::Result<String> {
+    // Combine the task's cache key with content hash for dedup
+    let content_key = ArtifactCache::content_key(data);
+    let combined = format!("{}:{}", task_cache_key, content_key);
+    let final_key = ArtifactCache::content_key(combined.as_bytes());
+
+    // Store using the combined key
+    let path = cache.root.join(&final_key);
+    if !path.exists() {
+        // Eviction handled internally by store()
+        cache.store(data)?;
+    }
+    Ok(final_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_cache(max_bytes: u64) -> ArtifactCache {
+        let dir = tempfile::tempdir().unwrap();
+        ArtifactCache::new(dir.keep(), max_bytes).unwrap()
+    }
+
+    #[test]
+    fn store_and_retrieve() {
+        let mut cache = temp_cache(1_048_576);
+        let data = b"hello world";
+        let key = cache.store(data).unwrap();
+
+        let retrieved = cache.retrieve(&key).unwrap();
+        assert_eq!(retrieved, Some(data.to_vec()));
+    }
+
+    #[test]
+    fn content_addressing_deduplication() {
+        let mut cache = temp_cache(1_048_576);
+        let data = b"same content";
+
+        let key1 = cache.store(data).unwrap();
+        let key2 = cache.store(data).unwrap();
+
+        assert_eq!(key1, key2, "Same content should produce same key");
+        assert_eq!(cache.entry_count(), 1, "Should only store once");
+    }
+
+    #[test]
+    fn cache_miss_returns_none() {
+        let mut cache = temp_cache(1_048_576);
+        let result = cache.retrieve("nonexistent").unwrap();
+        assert!(result.is_none());
+        assert_eq!(cache.stats(), (0, 1));
+    }
+
+    #[test]
+    fn cache_hit_tracking() {
+        let mut cache = temp_cache(1_048_576);
+        let key = cache.store(b"data").unwrap();
+
+        cache.retrieve(&key).unwrap();
+        cache.retrieve(&key).unwrap();
+        cache.retrieve("miss").unwrap();
+
+        assert_eq!(cache.stats(), (2, 1));
+    }
+
+    #[test]
+    fn eviction_under_pressure() {
+        // Max 100 bytes — each entry is ~10 bytes
+        let mut cache = temp_cache(100);
+
+        let mut keys = Vec::new();
+        for i in 0..15 {
+            let data = format!("item-{:04}", i);
+            let key = cache.store(data.as_bytes()).unwrap();
+            keys.push(key);
+            // Small delay to ensure distinct access times
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        // Cache should have evicted older entries to stay under 100 bytes
+        assert!(
+            cache.total_cached_bytes() <= 100,
+            "Cache should respect max_bytes limit: {} > 100",
+            cache.total_cached_bytes()
+        );
+
+        // Most recent entries should still be present
+        let last_key = keys.last().unwrap();
+        assert!(
+            cache.contains(last_key),
+            "Most recent entry should still be cached"
+        );
+    }
+
+    #[test]
+    fn cache_hit_skips_execution() {
+        // Simulates the pattern: check cache → hit → skip work
+        let mut cache = temp_cache(1_048_576);
+        let task_key = "task-cache-key-123";
+
+        // First run: no cache hit, execute and store result
+        let result = cache.retrieve(task_key).unwrap();
+        assert!(result.is_none(), "First run should be a cache miss");
+
+        // Store the "result" of execution
+        let output = b"execution output";
+        let _stored_key = cache.store(output).unwrap();
+
+        // Store under the task key as well
+        let task_path = cache.root.join(task_key);
+        std::fs::write(&task_path, output).unwrap();
+
+        // Second run: cache hit, skip execution
+        let cached = cache.retrieve(task_key).unwrap();
+        assert!(cached.is_some(), "Second run should be a cache hit");
+        assert_eq!(cached.unwrap(), output.to_vec());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod dag;
 pub mod error;
 pub mod lease;
@@ -8,6 +9,7 @@ pub mod scheduler;
 pub mod work_item;
 pub mod worker;
 
+pub use cache::ArtifactCache;
 pub use dag::DagEngine;
 pub use error::SchedulerError;
 pub use lease::{Lease, LeaseManager};


### PR DESCRIPTION
## Summary
- Add `ArtifactCache` — SHA256 content-addressed file store at configurable root directory
- Content deduplication: identical data stored once, keyed by SHA256 digest
- LRU eviction: configurable `max_bytes` limit with least-recently-used eviction policy
- Hit/miss tracking via `stats()` for observability
- Crash recovery: scans existing files on open to rebuild index
- `store_task_artifact()` helper combining task cache key with content hash

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all -- -D warnings` — zero warnings
- [x] `cargo test --all` — 57 tests pass (53 unit + 4 component)
- [x] `store_and_retrieve` — round-trip store → retrieve
- [x] `content_addressing_deduplication` — same data = same key, stored once
- [x] `cache_miss_returns_none` — unknown key returns None
- [x] `cache_hit_tracking` — hits/misses tracked correctly
- [x] `eviction_under_pressure` — LRU eviction keeps total under max_bytes
- [x] `cache_hit_skips_execution` — demonstrates the skip-on-hit pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)