### PR TITLE
NIX_SETUP.md: fill in real signing key + canonical cache.nixos.org-1

### DIFF
--- a/NIX_SETUP.md
+++ b/NIX_SETUP.md
@@ -21,7 +21,7 @@ To use the `nix-cache.stevedores.org` attic cache for faster builds, you need to
 
 ```nix
 substituters = https://nix-cache.stevedores.org/ https://cache.nixos.org/
-trusted-public-keys = nix-cache.stevedores.org:<PUBLIC_KEY> cache.nixos.org-1:6NCHdD59X431o0gWypG7a9Tv8sfqncan61pXZx54MKA=
+trusted-public-keys = stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 ```
 
 3. Restart the nix daemon:


### PR DESCRIPTION
## Summary
- Replace `nix-cache.stevedores.org:<PUBLIC_KEY>` placeholder with `stevedores-1:ZEtb+wHYNR/LDmMDhF3/EpRZDNma8exY2b1TGZ6uS2A=` (the org-wide signing key).
- Update `cache.nixos.org-1` value to the canonical `6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=`. The prior value (`...G7a9Tv8sfqncan61pXZx54MKA=`) did not match the key baked into the nix binary; following the doc as-is would cause signature validation failures on cache.nixos.org artifacts.

## Test plan
- [ ] Following the doc results in `nix build` succeeding without "no signatures" warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)