### PR TITLE
feat(coordinator): k8s-ready packaging — health probes + dockworker + kustomize

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,14 @@ knittingCrab/
 │       │   └── error.rs             # SessionError
 │       └── tests/
 │
+│   └── coordinator/                  # Server-side scheduler state (Epic 5)
+│       ├── src/
+│       │   ├── lib.rs               # Library exports
+│       │   └── main.rs               # Binary (K8s ready)
+│       └── tests/
+│
+├── kustomize/                        # K8s manifests (base/overlays)
+├── dockworker.toml                    # Containerization config
 ├── src/                              # (Old location, being migrated to crates/)
 │   └── ...                           # Legacy code; prefer crates/ structure
 │

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aivcs-session"
 version = "0.1.0"
 dependencies = [
@@ -122,6 +131,61 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -595,6 +659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +678,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -860,6 +931,7 @@ name = "knitting-crab-coordinator"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "axum",
  "chrono",
  "dashmap",
  "knitting-crab-core",
@@ -867,8 +939,12 @@ dependencies = [
  "knitting-crab-transport",
  "knitting-crab-worker",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
+ "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1029,6 +1105,21 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -1320,6 +1411,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,7 +1459,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1549,6 +1651,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1845,6 +1958,24 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1883,6 +2014,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1926,10 +2058,14 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,11 +56,13 @@ chrono = { version = "0.4", features = ["serde"] }
 async-trait = "0.1"
 proptest = "1"
 tokio-test = "0.4"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sha2 = "0.10"
 parking_lot = "0.12"
 rusqlite = { version = "0.30", features = ["bundled", "chrono"] }
 anyhow = "1.0"
+axum = "0.7"
+tower-http = { version = "0.5", features = ["trace"] }
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ A resource-aware distributed task scheduler for AI agent workloads on Apple Sili
 
 **Test Coverage**: 63+ tests passing with `RUSTFLAGS="-D warnings"`, zero unsafe code outside required OS interfaces
 
+## Deployment & Containerization
+
+### Coordinator (K8s)
+The **Coordinator** is containerized for standard Kubernetes deployment:
+- **Containerization**: `dockworker.toml` at repo root produces a hardened OCI image.
+- **Packaging**: Kustomize manifests in `kustomize/` (base + overlays).
+- **GitOps**: Managed via Flux in the `lornu.ai` ecosystem.
+- **Probes**: HTTP health checks on `:8080` (`/healthz`, `/readyz`).
+
+### Workers (Bare Metal)
+**Workers** remain on bare-metal Apple Silicon hosts to ensure direct NPU/GPU access and macOS process fidelity. They connect to the Coordinator via its K8s Service address (DNS or ClusterIP).
+
 ## Quick Start
 
 ### Prerequisites

--- a/crates/coordinator/Cargo.toml
+++ b/crates/coordinator/Cargo.toml
@@ -13,7 +13,12 @@ dashmap = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 async-trait = { workspace = true }
+axum = { workspace = true }
+tower-http = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 

--- a/crates/coordinator/src/main.rs
+++ b/crates/coordinator/src/main.rs
@@ -1,0 +1,70 @@
+use axum::{routing::get, Json, Router};
+use knitting_crab_coordinator::{CoordinatorServer, CoordinatorState};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tracing::{info, warn};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    info!("Starting knittingCrab coordinator");
+
+    let state = Arc::new(CoordinatorState::new());
+
+    // Main coordinator address (custom TCP protocol)
+    let coordinator_addr: SocketAddr = std::env::var("COORDINATOR_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:4000".to_string())
+        .parse()?;
+
+    // Health probe address (HTTP)
+    let health_addr: SocketAddr = std::env::var("HEALTH_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:8080".to_string())
+        .parse()?;
+
+    // Setup health routes
+    let app = Router::new()
+        .route("/health", get(health_check))
+        .route("/healthz", get(liveness))
+        .route("/readyz", get(readiness))
+        .with_state(Arc::clone(&state));
+
+    // Spawn coordinator server
+    let coordinator_state = (*state).clone();
+    tokio::spawn(async move {
+        let server = CoordinatorServer::new(coordinator_state, coordinator_addr);
+        if let Err(e) = server.serve().await {
+            warn!("Coordinator server error: {}", e);
+        }
+    });
+
+    // Start health HTTP server
+    info!("Health probes listening on {}", health_addr);
+    let listener = TcpListener::bind(health_addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+async fn health_check() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "status": "ok",
+        "service": "knitting-crab-coordinator"
+    }))
+}
+
+async fn liveness() -> &'static str {
+    "OK"
+}
+
+async fn readiness() -> &'static str {
+    // For now, always ready once started.
+    // In the future, check if at least one node is registered or catalog is loaded.
+    "OK"
+}

--- a/crates/coordinator/src/ssh_health.rs
+++ b/crates/coordinator/src/ssh_health.rs
@@ -100,7 +100,7 @@ mod tests {
         fn add_result(&self, hostname: &str, success: bool) {
             self.outcomes
                 .entry(hostname.to_string())
-                .or_insert_with(Vec::default)
+                .or_default()
                 .push(success);
         }
     }
@@ -134,7 +134,7 @@ mod tests {
             capacity: ResourceAllocation::default(),
             registered_at: Utc::now(),
             is_production: false,
-            };
+        };
 
         registry.register(node_info);
 
@@ -173,7 +173,7 @@ mod tests {
             capacity: ResourceAllocation::default(),
             registered_at: Utc::now(),
             is_production: false,
-            };
+        };
 
         registry.register(node_info);
 
@@ -211,7 +211,7 @@ mod tests {
             capacity: ResourceAllocation::default(),
             registered_at: Utc::now(),
             is_production: false,
-            };
+        };
 
         registry.register(node_info.clone());
 
@@ -250,7 +250,7 @@ mod tests {
             capacity: ResourceAllocation::default(),
             registered_at: Utc::now(),
             is_production: false,
-            };
+        };
 
         registry.register(node_info);
 
@@ -295,7 +295,7 @@ mod tests {
             capacity: ResourceAllocation::default(),
             registered_at: Utc::now(),
             is_production: false,
-            };
+        };
 
         let info2 = NodeInfo {
             worker_id: node2,
@@ -303,8 +303,7 @@ mod tests {
             capacity: ResourceAllocation::default(),
             registered_at: Utc::now(),
             is_production: false,
-            };
-
+        };
 
         registry.register(info1);
         registry.register(info2);
@@ -343,8 +342,7 @@ mod tests {
             capacity: ResourceAllocation::default(),
             registered_at: Utc::now(),
             is_production: false,
-            };
-
+        };
 
         registry.register(info1);
 
@@ -376,7 +374,7 @@ mod tests {
             capacity: ResourceAllocation::default(),
             registered_at: Utc::now(),
             is_production: false,
-            };
+        };
 
         registry.register(node_info);
 
@@ -404,8 +402,7 @@ mod tests {
             capacity: ResourceAllocation::default(),
             registered_at: Utc::now(),
             is_production: false,
-            };
-
+        };
 
         registry.register(info1);
 

--- a/crates/core/src/aivcs_ledger.rs
+++ b/crates/core/src/aivcs_ledger.rs
@@ -3,10 +3,10 @@
 //! Provides an event sink that records task lifecycle events into a content-addressed
 //! AIVCS run ledger, enabling auditability and sovereign feedback loops.
 
-use async_trait::async_trait;
 use crate::error::CoreError;
 use crate::event::{LogLine, TaskEvent};
 use crate::traits::EventSink;
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 /// Event structure expected by the AIVCS ledger API.
@@ -37,7 +37,11 @@ impl AivcsEventSink {
 
     /// Internal helper to check if an event should be forwarded based on a run_id.
     #[allow(dead_code)]
-    async fn record_if_context_exists(&self, run_id: &Option<String>, event: &TaskEvent) -> Result<(), CoreError> {
+    async fn record_if_context_exists(
+        &self,
+        run_id: &Option<String>,
+        event: &TaskEvent,
+    ) -> Result<(), CoreError> {
         if let Some(id) = run_id {
             let aivcs_event = AivcsLedgerEvent {
                 run_id: id.clone(),
@@ -46,12 +50,15 @@ impl AivcsEventSink {
                     TaskEvent::Completed { .. } => "TASK_COMPLETED".to_string(),
                     _ => "TASK_EVENT".to_string(),
                 },
-                payload: serde_json::to_value(event).map_err(|e| CoreError::Internal(e.to_string()))?,
+                payload: serde_json::to_value(event)
+                    .map_err(|e| CoreError::Internal(e.to_string()))?,
                 timestamp: chrono::Utc::now(),
             };
 
             // Fire and forget (or log error) for the prototype
-            let _ = self.client.post(&self.endpoint)
+            let _ = self
+                .client
+                .post(&self.endpoint)
                 .json(&aivcs_event)
                 .send()
                 .await;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod aivcs_ledger;
 pub mod agent;
+pub mod aivcs_ledger;
 pub mod backpressure_integration;
 pub mod circuit_breaker;
 pub mod error;
@@ -21,8 +21,8 @@ pub mod task_timeout;
 pub mod time_slice_scheduler;
 pub mod traits;
 
-pub use aivcs_ledger::{AivcsEventSink, AivcsLedgerEvent};
 pub use agent::{AgentBudget, TestGate};
+pub use aivcs_ledger::{AivcsEventSink, AivcsLedgerEvent};
 pub use backpressure_integration::{TaskExecutionFilter, TaskRejectionReason};
 pub use circuit_breaker::{
     CircuitBreaker, CircuitBreakerConfig, CircuitBreakerStats, CircuitState,
@@ -47,7 +47,7 @@ pub use task_aging::{AgingPolicy, TaskAge};
 pub use task_timeout::{TaskTimeoutManager, TimeoutHandle, TimeoutPolicy, TimeoutStatus};
 pub use time_slice_scheduler::{SchedulerState, SchedulerStats, TimeSliceScheduler};
 pub use traits::{
-    EventSink, EvaluationMetadata, ExecutionResult, LeaseStore, Queue, RemoteRole, RemoteSessionConfig,
-    RemoteSessionManager, RemoteSessionManagerTrait, ResourceMonitor, SessionConfig, SessionHandle,
-    TaskDescriptor,
+    EvaluationMetadata, EventSink, ExecutionResult, LeaseStore, Queue, RemoteRole,
+    RemoteSessionConfig, RemoteSessionManager, RemoteSessionManagerTrait, ResourceMonitor,
+    SessionConfig, SessionHandle, TaskDescriptor,
 };

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -323,7 +323,10 @@ mod tests {
         let json = serde_json::to_string(&desc).unwrap();
         let deserialized: TaskDescriptor = serde_json::from_str(&json).unwrap();
         assert_eq!(desc.evaluation, deserialized.evaluation);
-        assert_eq!(deserialized.evaluation.aivcs_run_id, Some("run-123".to_string()));
+        assert_eq!(
+            deserialized.evaluation.aivcs_run_id,
+            Some("run-123".to_string())
+        );
     }
 
     #[test]

--- a/crates/scheduler/src/gatekeeper.rs
+++ b/crates/scheduler/src/gatekeeper.rs
@@ -19,7 +19,10 @@ impl RosterGatekeeper {
 
         // Policy: Phase 1/2 agents (Local Loop / Ephemeral Hub) should be restricted to Dev nodes
         // to prevent interference with production workloads.
-        if task.evaluation.agent_phase > 0 && task.evaluation.agent_phase <= 2 && node.is_production() {
+        if task.evaluation.agent_phase > 0
+            && task.evaluation.agent_phase <= 2
+            && node.is_production()
+        {
             // Only allow if it's explicitly a promotion gate test.
             if !task.evaluation.is_promotion_gate {
                 return false;

--- a/dockworker.toml
+++ b/dockworker.toml
@@ -1,0 +1,35 @@
+# dockworker.ai configuration for stevedores-org/knittingCrab.
+#
+# Produces a hardened OCI image for the coordinator.
+# Workers remain on bare-metal Apple Silicon.
+
+[project]
+id = "${DOCKWORKER_PROJECT_ID}"
+name = "knitting-crab"
+
+[target.coordinator]
+context = "."
+runtime = "rust"
+# Binary name from crates/coordinator
+executable = "knitting-crab-coordinator"
+
+[target.coordinator.rust]
+# Ensure we build the specific crate
+package = "knitting-crab-coordinator"
+
+[target.coordinator.ports]
+# Main coordinator TCP port
+coordinator = 4000
+# Health probe HTTP port
+health = 8080
+
+[target.coordinator.env]
+# Default to listening on all interfaces inside the container
+COORDINATOR_ADDR = "0.0.0.0:4000"
+HEALTH_ADDR = "0.0.0.0:8080"
+RUST_LOG = "info,knitting_crab_coordinator=info"
+
+[mirror]
+# Mirror to the org's Azure Container Registry
+repository = "${ACR_NAME}.azurecr.io/knitting-crab"
+tags = ["latest", "${GIT_SHA}"]

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -1,0 +1,23 @@
+# Kustomize manifests for knitting-crab-coordinator
+
+K8s packaging for `crates/coordinator` per the org-wide kustomize convention.
+
+## Structure
+
+```
+kustomize/
+├── base/
+│   ├── namespace.yaml        # knitting-crab-system
+│   ├── deployment.yaml       # Coordinator deployment (hardened)
+│   ├── service.yaml          # ClusterIP (ports 4000, 8080)
+│   ├── configmap.yaml        # Default env vars
+│   └── kustomization.yaml    # Base aggregation
+└── overlays/
+    ├── dev/                  # Single replica, debug logging
+    └── prod/                 # 3 replicas, info logging
+```
+
+## Deployment
+
+The coordinator is containerized via `dockworker.toml` and deployed via Flux.
+Workers remain on bare-metal Apple Silicon and connect to the coordinator via its ClusterIP/DNS name.

--- a/kustomize/base/configmap.yaml
+++ b/kustomize/base/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: knitting-crab-config
+  namespace: knitting-crab-system
+data:
+  RUST_LOG: "info,knitting_crab_coordinator=info"
+  COORDINATOR_ADDR: "0.0.0.0:4000"
+  HEALTH_ADDR: "0.0.0.0:8080"

--- a/kustomize/base/deployment.yaml
+++ b/kustomize/base/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knitting-crab-coordinator
+  namespace: knitting-crab-system
+  labels:
+    app: knitting-crab-coordinator
+    lornu.ai/component: knitting-crab
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: knitting-crab-coordinator
+  template:
+    metadata:
+      labels:
+        app: knitting-crab-coordinator
+        lornu.ai/component: knitting-crab
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: coordinator
+          image: knitting-crab-coordinator:latest # Overridden by Flux
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 4000
+              name: coordinator
+            - containerPort: 8080
+              name: health
+          envFrom:
+            - configMapRef:
+                name: knitting-crab-config
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/kustomize/base/kustomization.yaml
+++ b/kustomize/base/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: knitting-crab-system
+
+labels:
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: knitting-crab
+      app.kubernetes.io/component: coordinator
+      app.kubernetes.io/managed-by: flux
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml

--- a/kustomize/base/namespace.yaml
+++ b/kustomize/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knitting-crab-system
+  labels:
+    lornu.ai/component: knitting-crab
+    lornu.ai/managed-by: flux

--- a/kustomize/base/service.yaml
+++ b/kustomize/base/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: knitting-crab-coordinator
+  namespace: knitting-crab-system
+  labels:
+    app: knitting-crab-coordinator
+    lornu.ai/component: knitting-crab
+spec:
+  type: ClusterIP
+  selector:
+    app: knitting-crab-coordinator
+  ports:
+    - port: 4000
+      targetPort: coordinator
+      name: coordinator
+    - port: 8080
+      targetPort: health
+      name: health

--- a/kustomize/overlays/dev/kustomization.yaml
+++ b/kustomize/overlays/dev/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: ConfigMap
+      name: knitting-crab-config
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: knitting-crab-config
+      data:
+        RUST_LOG: "debug,knitting_crab_coordinator=debug"

--- a/kustomize/overlays/prod/kustomization.yaml
+++ b/kustomize/overlays/prod/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: Deployment
+      name: knitting-crab-coordinator
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: knitting-crab-coordinator
+      spec:
+        replicas: 3
+  - target:
+      kind: ConfigMap
+      name: knitting-crab-config
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: knitting-crab-config
+      data:
+        RUST_LOG: "info,knitting_crab_coordinator=info"


### PR DESCRIPTION
This PR introduces standard K8s-ready packaging for the knittingCrab coordinator, following the pattern established in bond-api.

Changes:
- Added a dedicated binary for the coordinator (`crates/coordinator/src/main.rs`).
- Integrated `axum` for HTTP health probes (`/healthz`, `/readyz`) on port 8080.
- Added `dockworker.toml` for OCI image builds.
- Created `kustomize/` manifests (base + dev/prod overlays) in the `knitting-crab-system` namespace.
- Fixed a clippy warning in `ssh_health.rs`.
- Updated `README.md` and `CLAUDE.md` to reflect the new deployment model.

The coordinator is now container-native, while workers continue to run on bare-metal Apple Silicon.