### PR TITLE
fix: coordinator reaper, cancel path, spawn, and remote executor bugs

### DIFF
--- a/crates/coordinator/src/server.rs
+++ b/crates/coordinator/src/server.rs
@@ -224,10 +224,12 @@ impl CoordinatorServer {
             // Evict unhealthy nodes (active probe failures)
             let unhealthy = state.node_registry.unhealthy_nodes();
             for worker_id in unhealthy {
-                // Requeue active leases for this node
+                // Requeue active leases for this node only (mirror stale-node path).
                 if let Ok(leases) = state.active_leases().await {
                     for lease in leases {
-                        let _ = state.queue.requeue(lease.task_id, lease.attempt + 1).await;
+                        if lease.worker_id == worker_id {
+                            let _ = state.queue.requeue(lease.task_id, lease.attempt + 1).await;
+                        }
                     }
                 }
                 state.node_registry.remove(&worker_id);
@@ -318,5 +320,24 @@ mod tests {
         };
         let resp = CoordinatorServer::handle_request(&state, req3, &mut None).await;
         assert!(matches!(resp, CoordinatorResponse::CacheLocations(ref locs) if locs.len() == 1));
+    }
+
+    #[test]
+    fn unhealthy_reaper_filters_leases_by_worker_id() {
+        let unhealthy = WorkerId::new();
+        let healthy = WorkerId::new();
+        let leases = vec![
+            Lease::new(knitting_crab_core::ids::TaskId::new(), unhealthy, Duration::from_secs(30), 0),
+            Lease::new(knitting_crab_core::ids::TaskId::new(), healthy, Duration::from_secs(30), 0),
+        ];
+
+        let requeued: Vec<_> = leases
+            .iter()
+            .filter(|lease| lease.worker_id == unhealthy)
+            .map(|lease| lease.task_id)
+            .collect();
+
+        assert_eq!(requeued.len(), 1);
+        assert_eq!(requeued[0], leases[0].task_id);
     }
 }

--- a/crates/coordinator/src/server.rs
+++ b/crates/coordinator/src/server.rs
@@ -327,8 +327,18 @@ mod tests {
         let unhealthy = WorkerId::new();
         let healthy = WorkerId::new();
         let leases = vec![
-            Lease::new(knitting_crab_core::ids::TaskId::new(), unhealthy, Duration::from_secs(30), 0),
-            Lease::new(knitting_crab_core::ids::TaskId::new(), healthy, Duration::from_secs(30), 0),
+            Lease::new(
+                knitting_crab_core::ids::TaskId::new(),
+                unhealthy,
+                Duration::from_secs(30),
+                0,
+            ),
+            Lease::new(
+                knitting_crab_core::ids::TaskId::new(),
+                healthy,
+                Duration::from_secs(30),
+                0,
+            ),
         ];
 
         let requeued: Vec<_> = leases

--- a/crates/worker/src/fake_worker.rs
+++ b/crates/worker/src/fake_worker.rs
@@ -108,7 +108,9 @@ impl Queue for FakeWorker {
         Ok(())
     }
 
-    async fn discard(&self, _task_id: TaskId) -> Result<(), CoreError> {
+    async fn discard(&self, task_id: TaskId) -> Result<(), CoreError> {
+        let mut q = self.queue.lock().unwrap();
+        q.retain(|task| task.task_id != task_id);
         Ok(())
     }
 }

--- a/crates/worker/src/process.rs
+++ b/crates/worker/src/process.rs
@@ -120,7 +120,11 @@ pub async fn spawn(
     let span = tracing::info_span!("process_spawn", task_id = %params.task_id);
     let _enter = span.enter();
 
-    let mut cmd = std::process::Command::new(&params.command[0]);
+    let program = params.command.first().ok_or_else(|| {
+        WorkerError::SpawnFailed("empty command".into())
+    })?;
+
+    let mut cmd = std::process::Command::new(program);
 
     if params.command.len() > 1 {
         cmd.args(&params.command[1..]);
@@ -148,7 +152,7 @@ pub async fn spawn(
     let mut tokio_cmd = tokio::process::Command::from(cmd);
 
     let mut child = tokio_cmd.spawn().map_err(|e| {
-        WorkerError::SpawnFailed(format!("failed to spawn {}: {}", params.command[0], e))
+        WorkerError::SpawnFailed(format!("failed to spawn {}: {}", program, e))
     })?;
 
     let task_id = params.task_id;
@@ -514,6 +518,23 @@ mod tests {
             logs
         );
         assert!(stderr_logs.iter().any(|l| l.content.contains("stderr_msg")));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_empty_command_rejected() {
+        let sink = Arc::new(TestSink {
+            logs: Mutex::new(Vec::new()),
+        });
+        let params = SpawnParams {
+            task_id: TaskId::new(),
+            command: vec![],
+            working_dir: PathBuf::from("/tmp"),
+            env: Default::default(),
+            location: ExecutionLocation::default(),
+        };
+
+        let result = spawn(params, sink).await;
+        assert!(matches!(result, Err(WorkerError::SpawnFailed(_))));
     }
 
     #[tokio::test]

--- a/crates/worker/src/process.rs
+++ b/crates/worker/src/process.rs
@@ -120,9 +120,10 @@ pub async fn spawn(
     let span = tracing::info_span!("process_spawn", task_id = %params.task_id);
     let _enter = span.enter();
 
-    let program = params.command.first().ok_or_else(|| {
-        WorkerError::SpawnFailed("empty command".into())
-    })?;
+    let program = params
+        .command
+        .first()
+        .ok_or_else(|| WorkerError::SpawnFailed("empty command".into()))?;
 
     let mut cmd = std::process::Command::new(program);
 
@@ -151,9 +152,9 @@ pub async fn spawn(
     // Convert to tokio::process::Command
     let mut tokio_cmd = tokio::process::Command::from(cmd);
 
-    let mut child = tokio_cmd.spawn().map_err(|e| {
-        WorkerError::SpawnFailed(format!("failed to spawn {}: {}", program, e))
-    })?;
+    let mut child = tokio_cmd
+        .spawn()
+        .map_err(|e| WorkerError::SpawnFailed(format!("failed to spawn {}: {}", program, e)))?;
 
     let task_id = params.task_id;
     let sink_clone = Arc::clone(&sink);

--- a/crates/worker/src/ssh_tmux_executor.rs
+++ b/crates/worker/src/ssh_tmux_executor.rs
@@ -27,9 +27,17 @@ impl SshTmuxSessionExecutor {
         Self { session_manager }
     }
 
-    /// Generate a deterministic session name for a task.
-    fn session_name_for_task(task_id: TaskId) -> String {
-        format!("kc_{}", task_id.to_string().replace("-", "_"))
+    /// Shell-escape a single argv element for use inside `sh -c '…'`.
+    fn shell_escape_arg(arg: &str) -> String {
+        format!("'{}'", arg.replace('\'', "'\"'\"'"))
+    }
+
+    /// Join argv into a shell-safe command string (preserves argument boundaries).
+    fn shell_join(args: &[String]) -> String {
+        args.iter()
+            .map(|arg| Self::shell_escape_arg(arg))
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 
     /// Generate sentinel file path for exit code polling.
@@ -48,9 +56,12 @@ impl ProcessExecutor for SshTmuxSessionExecutor {
         mut cancel_guard: CancelGuard,
     ) -> Result<ExitOutcome, WorkerError> {
         let task_id = params.task_id;
-        let session_name = Self::session_name_for_task(task_id);
         let sentinel_path = Self::sentinel_path_for_task(task_id);
         let window_name = "main";
+
+        if params.command.is_empty() {
+            return Err(WorkerError::SpawnFailed("empty command".into()));
+        }
 
         // Ensure session exists
         let config = match &params.location {
@@ -71,15 +82,16 @@ impl ProcessExecutor for SshTmuxSessionExecutor {
             }
         };
 
-        self.session_manager
+        let session_name = self
+            .session_manager
             .ensure_session(&config)
             .await
             .map_err(|e| WorkerError::Internal(format!("ensure_session failed: {}", e)))?;
 
-        debug!("Created session: {}", session_name);
+        debug!("Using session: {}", session_name);
 
         // Build command with sentinel file wrapper
-        let command_str = params.command.join(" ");
+        let command_str = Self::shell_join(&params.command);
         let wrapped_command = format!("sh -c '({}); echo $? > {}'", command_str, sentinel_path);
 
         // Run command in session
@@ -150,6 +162,66 @@ impl SshTmuxSessionExecutor {
 mod tests {
     use super::*;
     use crate::fake_session_manager::{ExitCodeBehavior, FakeRemoteSessionManager};
+
+    #[tokio::test]
+    async fn success_path_uses_session_from_ensure_session() {
+        let fake_manager = Arc::new(FakeRemoteSessionManager::new());
+        let executor = SshTmuxSessionExecutor::new(fake_manager.clone());
+
+        let params = SpawnParams {
+            task_id: TaskId::new(),
+            command: vec!["echo".to_string(), "hello".to_string()],
+            working_dir: std::path::PathBuf::from("/tmp"),
+            env: Default::default(),
+            location: knitting_crab_core::ExecutionLocation::default(),
+        };
+
+        let sink = Arc::new(crate::fake_worker::FakeWorker::new()) as Arc<dyn EventSink>;
+        let (_token, guard) = crate::CancelToken::new();
+
+        let _ = executor.execute(params, sink, guard).await.unwrap();
+
+        let calls = fake_manager.drain_calls();
+        let ensure = calls
+            .iter()
+            .find(|c| c.method == "ensure_session")
+            .expect("ensure_session called");
+        let run = calls
+            .iter()
+            .find(|c| c.method == "run_command_in_session")
+            .expect("run_command_in_session called");
+        assert_eq!(run.session_name, ensure.session_name);
+    }
+
+    #[test]
+    fn shell_join_preserves_argument_boundaries() {
+        let joined = SshTmuxSessionExecutor::shell_join(&[
+            "echo".to_string(),
+            "hello world".to_string(),
+            "it's".to_string(),
+        ]);
+        assert_eq!(joined, "'echo' 'hello world' 'it'\"'\"'s'");
+    }
+
+    #[tokio::test]
+    async fn empty_command_is_rejected() {
+        let fake_manager = Arc::new(FakeRemoteSessionManager::new());
+        let executor = SshTmuxSessionExecutor::new(fake_manager);
+
+        let params = SpawnParams {
+            task_id: TaskId::new(),
+            command: vec![],
+            working_dir: std::path::PathBuf::from("/tmp"),
+            env: Default::default(),
+            location: knitting_crab_core::ExecutionLocation::default(),
+        };
+
+        let sink = Arc::new(crate::fake_worker::FakeWorker::new()) as Arc<dyn EventSink>;
+        let (_token, guard) = crate::CancelToken::new();
+
+        let err = executor.execute(params, sink, guard).await.unwrap_err();
+        assert!(matches!(err, WorkerError::SpawnFailed(_)));
+    }
 
     #[tokio::test]
     async fn success_path_returns_exit_outcome_success() {

--- a/crates/worker/src/ssh_tmux_executor.rs
+++ b/crates/worker/src/ssh_tmux_executor.rs
@@ -27,17 +27,26 @@ impl SshTmuxSessionExecutor {
         Self { session_manager }
     }
 
-    /// Shell-escape a single argv element for use inside `sh -c '…'`.
-    fn shell_escape_arg(arg: &str) -> String {
-        format!("'{}'", arg.replace('\'', "'\"'\"'"))
+    /// Escape a string for use inside double quotes in a `sh -c "…"` script.
+    fn shell_escape_sh_double(s: &str) -> String {
+        s.replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('$', "\\$")
+            .replace('`', "\\`")
     }
 
     /// Join argv into a shell-safe command string (preserves argument boundaries).
     fn shell_join(args: &[String]) -> String {
         args.iter()
-            .map(|arg| Self::shell_escape_arg(arg))
+            .map(|arg| format!("\"{}\"", Self::shell_escape_sh_double(arg)))
             .collect::<Vec<_>>()
             .join(" ")
+    }
+
+    /// Build `sh -c` wrapper that runs argv and writes exit code to the sentinel file.
+    fn build_wrapped_command(args: &[String], sentinel_path: &str) -> String {
+        let inner = format!("({}); echo $? > {sentinel_path}", Self::shell_join(args));
+        format!("sh -c \"{}\"", Self::shell_escape_sh_double(&inner))
     }
 
     /// Generate sentinel file path for exit code polling.
@@ -91,8 +100,7 @@ impl ProcessExecutor for SshTmuxSessionExecutor {
         debug!("Using session: {}", session_name);
 
         // Build command with sentinel file wrapper
-        let command_str = Self::shell_join(&params.command);
-        let wrapped_command = format!("sh -c '({}); echo $? > {}'", command_str, sentinel_path);
+        let wrapped_command = Self::build_wrapped_command(&params.command, &sentinel_path);
 
         // Run command in session
         self.session_manager
@@ -200,7 +208,31 @@ mod tests {
             "hello world".to_string(),
             "it's".to_string(),
         ]);
-        assert_eq!(joined, "'echo' 'hello world' 'it'\"'\"'s'");
+        assert_eq!(joined, "\"echo\" \"hello world\" \"it's\"");
+    }
+
+    #[test]
+    fn build_wrapped_command_is_valid_sh_syntax() {
+        let sentinel = "/tmp/kc_exit_abc123";
+        let wrapped = SshTmuxSessionExecutor::build_wrapped_command(
+            &[
+                "echo".to_string(),
+                "hello world".to_string(),
+                "it's".to_string(),
+            ],
+            sentinel,
+        );
+        assert!(wrapped.starts_with("sh -c \""));
+        assert!(wrapped.contains("hello world"));
+        assert!(wrapped.ends_with(&format!("> {sentinel}\"")));
+
+        let status = std::process::Command::new("sh")
+            .arg("-n")
+            .arg("-c")
+            .arg(&wrapped)
+            .status()
+            .expect("sh -n");
+        assert!(status.success(), "wrapped command must be valid sh syntax");
     }
 
     #[tokio::test]

--- a/crates/worker/src/worker_runtime.rs
+++ b/crates/worker/src/worker_runtime.rs
@@ -257,6 +257,7 @@ impl<
         let heartbeat_task_id = task.task_id;
         let heartbeat_interval = self.heartbeat_interval_ms;
         let lease_store = self.lease_store.clone();
+        let lease_ttl = self.lease_ttl;
 
         let heartbeat_handle = tokio::spawn(async move {
             let mut ticker = interval(Duration::from_millis(heartbeat_interval));
@@ -265,9 +266,7 @@ impl<
                 if let Ok(None) = lease_store.get(heartbeat_task_id).await {
                     break;
                 }
-                let _ = lease_manager
-                    .renew(heartbeat_task_id, Duration::from_secs(30))
-                    .await;
+                let _ = lease_manager.renew(heartbeat_task_id, lease_ttl).await;
             }
         });
 
@@ -390,13 +389,16 @@ impl<
             token.cancel();
         }
 
-        if self.lease_store.get(task_id).await?.is_some() {
+        let had_lease = self.lease_store.get(task_id).await?.is_some();
+        if had_lease {
             self.lease_manager.cancel(task_id).await?;
-            self.event_sink
-                .emit_event(TaskEvent::Cancelled { task_id })
-                .await?;
-            self.queue.discard(task_id).await?;
         }
+
+        // Queued-but-not-yet-leased tasks must still be removed from the queue.
+        self.queue.discard(task_id).await?;
+        self.event_sink
+            .emit_event(TaskEvent::Cancelled { task_id })
+            .await?;
 
         Ok(())
     }
@@ -586,7 +588,7 @@ mod tests {
             queue.clone(),
             lease_store,
             resource_monitor,
-            event_sink,
+            event_sink.clone(),
             process_executor,
         );
 
@@ -610,6 +612,15 @@ mod tests {
         queue.enqueue(task.clone());
         let cancel_result = runtime.cancel_task(task_id).await;
         assert!(cancel_result.is_ok(), "cancel should succeed");
+        let remaining = queue.dequeue(worker_id).await.unwrap();
+        assert!(remaining.is_none(), "queued task should be discarded on cancel");
+        let events = event_sink.drain_events();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, TaskEvent::Cancelled { .. })),
+            "cancel should emit Cancelled event"
+        );
     }
 
     #[test]

--- a/crates/worker/src/worker_runtime.rs
+++ b/crates/worker/src/worker_runtime.rs
@@ -613,7 +613,10 @@ mod tests {
         let cancel_result = runtime.cancel_task(task_id).await;
         assert!(cancel_result.is_ok(), "cancel should succeed");
         let remaining = queue.dequeue(worker_id).await.unwrap();
-        assert!(remaining.is_none(), "queued task should be discarded on cancel");
+        assert!(
+            remaining.is_none(),
+            "queued task should be discarded on cancel"
+        );
         let events = event_sink.drain_events();
         assert!(
             events


### PR DESCRIPTION
## Summary

Bug-hunt fixes across coordinator and worker crates:

| Severity | Area | Fix |
|----------|------|-----|
| **High** | `node_reaper_loop` (unhealthy path) | Only requeue leases for the evicted worker (was requeueing all active leases) |
| **High** | `cancel_task` | Discard queued-but-unleased tasks; always emit `Cancelled` |
| **High** | `process::spawn` | Reject empty command instead of indexing panic |
| **High** | `SshTmuxSessionExecutor` | Use session name returned by `ensure_session`; shell-escape argv |
| **Medium** | Heartbeat renew | Use configured `lease_ttl` instead of hardcoded 30s |

## Tests

- Regression tests for cancel/discard, empty command, shell escaping, session routing
- `FakeWorker::discard` now removes tasks (was no-op, masking cancel bugs)

## Verification

```sh
cargo test --workspace
cargo clippy --workspace -- -D warnings
```